### PR TITLE
updated debian version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bookworm
 MAINTAINER Adrian Dvergsdal [atmoz.net]
 
 # Steps done in one RUN layer:


### PR DESCRIPTION
Simple PR to update from bullseye to bookworm.

A docker image with latest has been pushed to benefex-assets