### PR TITLE
PLT-307\updated from debian 12 to debian 13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm
+FROM debian:trixie
 MAINTAINER Adrian Dvergsdal [atmoz.net]
 
 # Steps done in one RUN layer:


### PR DESCRIPTION
🎫 Jira ticket
https://benefex.atlassian.net/browse/PLT-307

🗒️ What's being changed?
Updated from debian 12 to debian 13

⁉️ Why is it being changed?
Debian 12 Bookworm and libssh2-1 candidate remains 1.10.0-3+b1, which Debian still marks vulnerable to CVE-2026-55200. DSA-6365-1 currently fixes Trixie only via 1.11.1-1+deb13u1

💣 Potential Impact
The container image will now use Debian 13 instead of Debian 12.
Package versions and dependencies may differ due to the base image upgrade.
SFTP functionality should remain unchanged, but runtime compatibility should be verified.
Any scripts or packages relying on Debian 12-specific behaviour may be affected.

🧪 How to test/verify the change?
Build the updated Docker image successfully.
Confirm the container starts without errors.
Verify the installed Debian version is 13 / Trixie.
libssh2 1.11.1-1+deb13u1 is installed after running apt-get install -y acl curl gnupg wget lsb-release